### PR TITLE
Add user quit time and online status to UserSettings

### DIFF
--- a/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettings.java
+++ b/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettings.java
@@ -42,4 +42,47 @@ public sealed interface UserSettings permits UserSettingsProvider {
      * @return The first join date of the user.
      */
     String getFirstJoinDate(int id);
+
+    /**
+     * Sets the last quit time for a user identified by the given ID.
+     * This method updates the last quit time of the user in the user settings database.
+     *
+     * @param id   The ID of the user.
+     * @param time The last quit time to set for the user, represented as a long value.
+     */
+    void setLastQuitTime(int id, long time);
+
+    /**
+     * Retrieves the last quit time of a user.
+     *
+     * @param id The id of the user.
+     * @return The last quit time of the user as a long value.
+     */
+    long getLastQuitTime(int id);
+
+    /**
+     * Retrieves the last quit date of a user identified by the given ID.
+     *
+     * @param id The ID of the user.
+     * @return The last quit date of the user as a string.
+     */
+    String getLastQuitDate(int id);
+
+    /**
+     * Sets the online status of a user identified by the given ID.
+     * This method updates the online status of the user in the user settings database.
+     *
+     * @param id     The ID of the user.
+     * @param online The online status to set for the user, represented as a byte value.
+     */
+    void setOnline(int id, int online);
+
+    /**
+     * Retrieves the online status of a user identified by the given ID.
+     * This method retrieves the online status of the user from the user settings database.
+     *
+     * @param id The ID of the user.
+     * @return The online status of the user as a boolean value. True indicates that the user is online, false indicates that the user is offline.
+     */
+    int getOnline(int id);
 }

--- a/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettingsProvider.java
+++ b/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettingsProvider.java
@@ -13,7 +13,7 @@ public final class UserSettingsProvider implements UserSettings {
     }
 
     private void createTable() {
-        Database.update("CREATE TABLE IF NOT EXISTS %s (ID INT PRIMARY KEY, FirstJoin BIGINT(255))", TABLE_NAME);
+        Database.update("CREATE TABLE IF NOT EXISTS %s (ID INT PRIMARY KEY, FirstJoin BIGINT(255), LastQuit BIGINT(255), IsOnline BOOL)", TABLE_NAME);
     }
 
     @Override
@@ -24,7 +24,7 @@ public final class UserSettingsProvider implements UserSettings {
     @Override
     public void createUser(int id) {
         if (existsUser(id)) return;
-        Database.update("CALL %s('%s','%s')", Procedure.PROCEDURE_INSERT.getName(), id, System.currentTimeMillis());
+        Database.update("CALL %s('%s','%s','%s')", Procedure.PROCEDURE_INSERT.getName(), id, System.currentTimeMillis(), System.currentTimeMillis(), 0);
     }
 
     @Override
@@ -42,10 +42,37 @@ public final class UserSettingsProvider implements UserSettings {
         return new SimpleDateFormat("dd.MM.yyyy HH:mm:ss").format(getFirstJoinTime(id));
     }
 
+    @Override
+    public void setLastQuitTime(int id, long time) {
+        Database.update("CALL %s('%s','%s')", Procedure.PROCEDURE_UPDATE_LAST_QUIT.getName(), id, time);
+    }
+
+    @Override
+    public long getLastQuitTime(int id) {
+        return Database.getLong(-1, "LastQuit", "CALL %s('%s')", Procedure.PROCEDURE_ID.getName(), id);
+    }
+
+    @Override
+    public String getLastQuitDate(int id) {
+        return new SimpleDateFormat("dd.MM.yyyy HH:mm:ss").format(getLastQuitTime(id));
+    }
+
+    @Override
+    public void setOnline(int id, int online) {
+        Database.update("CALL %s('%s','%s')", Procedure.PROCEDURE_UPDATE_ONLINE.getName(), id, online);
+    }
+
+    @Override
+    public int getOnline(int id) {
+        return Database.getInt(0, "IsOnline", "CALL %s('%s')", Procedure.PROCEDURE_ID.getName(), id);
+    }
+
     private enum Procedure {
         PROCEDURE_ID("UserSettings_ID", Database.getProcedureQuery("UserSettings_ID", "uid INT", "SELECT * FROM %s WHERE ID=uid;", TABLE_NAME)),
-        PROCEDURE_INSERT("UserSettings_Insert", Database.getProcedureQuery("UserSettings_Insert", "uid INT, time BIGINT(255)", "INSERT INTO %s VALUES (uid, time);", TABLE_NAME)),
-        PROCEDURE_DELETE("UserSettings_Delete", Database.getProcedureQuery("UserSettings_Delete", "uid INT", "DELETE FROM %s WHERE ID=uid;", TABLE_NAME));
+        PROCEDURE_INSERT("UserSettings_Insert", Database.getProcedureQuery("UserSettings_Insert", "uid INT, first BIGINT(255), last BIGINT(255), online BOOL", "INSERT INTO %s VALUES (uid, first, last, online);", TABLE_NAME)),
+        PROCEDURE_DELETE("UserSettings_Delete", Database.getProcedureQuery("UserSettings_Delete", "uid INT", "DELETE FROM %s WHERE ID=uid;", TABLE_NAME)),
+        PROCEDURE_UPDATE_ONLINE("UserSettings_UpdateOnline", Database.getProcedureQuery("UserSettings_UpdateOnline", "uid INT, online BOOL", "UPDATE %s SET IsOnline=online WHERE ID=uid;", TABLE_NAME)),
+        PROCEDURE_UPDATE_LAST_QUIT("UserSettings_UpdateLastQuit", Database.getProcedureQuery("UserSettings_UpdateLastQuit", "uid INT, last BIGINT(255)", "UPDATE %s SET LastQuit=last WHERE ID=uid;", TABLE_NAME));
         private static final Procedure[] VALUES = values();
 
         private final String name;

--- a/src/main/java/de/murmelmeister/murmelapi/utils/TimeUtil.java
+++ b/src/main/java/de/murmelmeister/murmelapi/utils/TimeUtil.java
@@ -90,6 +90,23 @@ public final class TimeUtil {
                + (seconds != 0 ? getTimeValue(seconds, PlayTimeType.SECONDS) : "");
     }
 
+    /**
+     * Formats the given play time into a scoreboard time string.
+     *
+     * @param playTime The PlayTime object to get the time from.
+     * @param userId   The ID of the user.
+     * @return The formatted time value as a string representing the time in days, hours, and years.
+     */
+    public static String formatScoreboardTime(PlayTime playTime, int userId) {
+        long hours = playTime.getTime(userId, PlayTimeType.HOURS);
+        long days = playTime.getTime(userId, PlayTimeType.DAYS);
+        long years = playTime.getTime(userId, PlayTimeType.YEARS);
+
+        return (years != 0 ? getTimeValue(years, PlayTimeType.YEARS).replace("365 days", "") + " " : "")
+               + (days != 0 ? getTimeValue(days, PlayTimeType.DAYS).replace("24 hours", "") + " " : "")
+               + (hours != 0 ? getTimeValue(hours, PlayTimeType.HOURS) : "0 ");
+    }
+
 
     /**
      * Returns the formatted time value based on the given time and PlayTimeType.


### PR DESCRIPTION
This commit expands UserSettings functionalities with creation of several new methods. The methods are targeted at retrieving and updating last quit date/time of a user and online status of a user. UserSettingsProvider was also updated accordingly. A new ScoreBoardTime format was also added in TimeUtil class.