### PR TITLE
Fix incorrect SQL call in createUser method

### DIFF
--- a/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettingsProvider.java
+++ b/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettingsProvider.java
@@ -24,7 +24,7 @@ public final class UserSettingsProvider implements UserSettings {
     @Override
     public void createUser(int id) {
         if (existsUser(id)) return;
-        Database.update("CALL %s('%s','%s','%s')", Procedure.PROCEDURE_INSERT.getName(), id, System.currentTimeMillis(), System.currentTimeMillis(), 0);
+        Database.update("CALL %s('%s','%s','%s','%s')", Procedure.PROCEDURE_INSERT.getName(), id, System.currentTimeMillis(), System.currentTimeMillis(), 0);
     }
 
     @Override


### PR DESCRIPTION
The SQL call in the createUser method mistakenly had one parameter missing. Added the missing parameter to ensure the procedure executes correctly with all required arguments.