### PR TITLE
Add user parameter to UserSettingsProvider constructor

### DIFF
--- a/src/main/java/de/murmelmeister/murmelapi/user/UserProvider.java
+++ b/src/main/java/de/murmelmeister/murmelapi/user/UserProvider.java
@@ -25,7 +25,7 @@ public final class UserProvider implements User {
     public UserProvider() {
         this.createTable();
         Procedure.loadAll();
-        this.settings = new UserSettingsProvider();
+        this.settings = new UserSettingsProvider(this);
         this.parent = new UserParentProvider();
         this.permission = new UserPermissionProvider();
         this.playTime = new PlayTimeProvider(this);

--- a/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettingsProvider.java
+++ b/src/main/java/de/murmelmeister/murmelapi/user/settings/UserSettingsProvider.java
@@ -1,5 +1,6 @@
 package de.murmelmeister.murmelapi.user.settings;
 
+import de.murmelmeister.murmelapi.user.User;
 import de.murmelmeister.murmelapi.utils.Database;
 
 import java.text.SimpleDateFormat;
@@ -7,9 +8,10 @@ import java.text.SimpleDateFormat;
 public final class UserSettingsProvider implements UserSettings {
     private static final String TABLE_NAME = "UserSettings";
 
-    public UserSettingsProvider() {
+    public UserSettingsProvider(User user) {
         this.createTable();
         Procedure.loadAll();
+        loadTablesIfNotCreated(user);
     }
 
     private void createTable() {
@@ -65,6 +67,11 @@ public final class UserSettingsProvider implements UserSettings {
     @Override
     public int getOnline(int id) {
         return Database.getInt(0, "IsOnline", "CALL %s('%s')", Procedure.PROCEDURE_ID.getName(), id);
+    }
+
+    private void loadTablesIfNotCreated(User user) {
+        for (var userId : user.getIds())
+            createUser(userId);
     }
 
     private enum Procedure {


### PR DESCRIPTION
This change refactors the UserSettingsProvider constructor to take a User parameter. It allows the class to load user-specific tables if they are not already created, improving initialization logic and ensuring correct setup for user-specific settings.